### PR TITLE
bgpd: Show routes filtered by prefix-list in filter-routes command

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -10234,19 +10234,17 @@ static void show_adj_route(struct vty *vty, struct peer *peer, afi_t afi,
 					route_filtered = true;
 
 				/* Filter prefix using route-map */
-				if ((bgp_input_modifier(peer, &rn->p, &attr,
-							afi, safi, rmap_name))
-					== RMAP_DENY)
-					route_filtered = true;
+				ret = bgp_input_modifier(peer, &rn->p, &attr,
+							afi, safi, rmap_name);
 
-				if (type == bgp_show_adj_route_filtered
-				    && !route_filtered) {
+				if (type == bgp_show_adj_route_filtered &&
+					!route_filtered && ret != RMAP_DENY) {
 					bgp_attr_undup(&attr, ain->attr);
 					continue;
 				}
 
-				if (type == bgp_show_adj_route_received
-				    && route_filtered)
+				if (type == bgp_show_adj_route_received &&
+					(route_filtered || ret == RMAP_DENY))
 					filtered_count++;
 
 				route_vty_out_tmp(vty, &rn->p, &attr, safi,

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -10101,6 +10101,7 @@ static void show_adj_route(struct vty *vty, struct peer *peer, afi_t afi,
 	json_object *json_ocode = NULL;
 	json_object *json_ar = NULL;
 	struct peer_af *paf;
+	bool route_filtered;
 
 	if (use_json) {
 		json_scode = json_object_new_object();
@@ -10223,17 +10224,29 @@ static void show_adj_route(struct vty *vty, struct peer *peer, afi_t afi,
 				}
 
 				bgp_attr_dup(&attr, ain->attr);
-				ret = bgp_input_modifier(peer, &rn->p, &attr,
-							 afi, safi, rmap_name);
+				route_filtered = false;
+
+				/* Filter prefix using distribute list,
+				 * filter list or prefix list
+				 */
+				if ((bgp_input_filter(peer, &rn->p, &attr, afi,
+						safi)) == FILTER_DENY)
+					route_filtered = true;
+
+				/* Filter prefix using route-map */
+				if ((bgp_input_modifier(peer, &rn->p, &attr,
+							afi, safi, rmap_name))
+					== RMAP_DENY)
+					route_filtered = true;
 
 				if (type == bgp_show_adj_route_filtered
-				    && ret != RMAP_DENY) {
+				    && !route_filtered) {
 					bgp_attr_undup(&attr, ain->attr);
 					continue;
 				}
 
 				if (type == bgp_show_adj_route_received
-				    && ret == RMAP_DENY)
+				    && route_filtered)
 					filtered_count++;
 
 				route_vty_out_tmp(vty, &rn->p, &attr, safi,


### PR DESCRIPTION
Changed "show bgp ipv4 neighbor <peer> filtered-routes"
to show routes filtered by prefx lists, distribute lists and filter lists

Closes: #2653

Signed-off-by: Ameya Dharkar adharkar@vmware.com